### PR TITLE
Added a function to supply bike-rider model numerical constants.

### DIFF
--- a/muscle-bike-paper.yml
+++ b/muscle-bike-paper.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - ipython
   - matplotlib
-  - mpmath
+  - mpmath  # sympy dependency
   - numpy
   - python
   - scikits.odes


### PR DESCRIPTION
You can do this to get the parameter dict you need for opty:

```python
sym = gen_eom_for_opty()
num = constants_values()
dict(zip(sym['parameters'], num))
```

or


```python
sym = gen_eom_for_opty(False)
num = constants_values(False)
dict(zip(sym['parameters'], num))
```
